### PR TITLE
Allow space between comment character and `<<`

### DIFF
--- a/_extensions/line-highlight/line-highlight.lua
+++ b/_extensions/line-highlight/line-highlight.lua
@@ -1,4 +1,4 @@
-local PATTERN = "#<<$"
+local PATTERN = "# ?<<$"
 
 local function ensureHtmlDeps()
   quarto.doc.add_html_dependency({


### PR DESCRIPTION
Hi @shafayetShafee and thanks for this quarto extension! I'm particularly happy that you've brought this syntax to Python since [I authored this feature for xaringan](https://www.garrickadenbuie.com/blog/highlight-lines-without-breaking-the-code-in-xaringan/) 😄 

For quarto, I'd like to propose allowing a space between the comment character and the `<<`. In particular, Python users tend to use [black](https://github.com/psf/black) for their code formatting and it's quite opinionated. It strictly enforces spaces between `#` and `<<`, so it rewrites the line highlight flag from `#<<` to `# <<`. Getting around it is quite tricky.

It'd be great if a single space were allowed, so either `#<<` or `# <<` are recognized. I've added this to the PATTERN regex in the lua code. Let me know if there's anything else I'd need to do for this PR!